### PR TITLE
guides/sev: add more details about SEV policy

### DIFF
--- a/guides/sev.md
+++ b/guides/sev.md
@@ -69,10 +69,17 @@ Port 44444 is the default port per the directions below, but it may be configure
 The KBS IP must be accessible from inside the guest.
 Usually it should be the public IP of the node where `simple-kbs` runs.
 
-The SEV policy can also be set by adding `io.katacontainers.config.sev.policy: "<SEV POLICY>"` to your pod configuration.
-Setting the second bit of the policy enables SEV-ES.
-For more information see chapter 3 of the Secure Encrypted Virtualization API.
-The SEV policy is not the same as the policies that drive `simple-kbs`.
+The SEV policy can also be set by adding `io.katacontainers.config.sev.policy: "<SEV POLICY>"` to your pod configuration. The default policy for SEV and SEV-ES are, respectively, "3" and "7", where the following bits are enabled:
+
+| Bit| Name| Description |
+| --- | --- | --- |
+|0|NODBG| Debugging of the guest is disallowed |
+|1|NOKS| Sharing keys with other guests is disallowed |
+|2|ES| SEV-ES is required |
+
+For more information about SEV policy, see chapter 3 of the [Secure Encrypted Virtualization API](https://www.amd.com/system/files/TechDocs/55766_SEV-KM_API_Specification.pdf) (PDF).
+
+>Note: the SEV policy is not the same as the policies that drive `simple-kbs`.
 
 The CoCo project has created a sample encrypted container image ([encrypted-image-tests](ghcr.io/fitzthum/encrypted-image-tests:encrypted)). This image is encrypted using a key that comes already provisioned inside the `simple-kbs` for ease of testing. No `simple-kbs` policy is required to get things running.
 


### PR DESCRIPTION
Updated the SEV guide with information about the default values of the SEV policy for SEV and SEV-ES as well as the features enabled/disabled.