### PR TITLE
Update intel rep to steering committee

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -78,11 +78,15 @@ The current members of the SC are:
 * Larry Dewey (@larrydewey) - AMD
 * Jiang Liu (@jiangliu) and Jia Zhang (@jiazhang0) - Alibaba
 * James Magowan (@magowan)  and Tobin Feldman-Fitzthum (@fitzthum) - IBM
-* Peter Zhu (@peterzcst) and Dan Middleton (@dcmiddle) - Intel
+* Peter Zhu (@peterzcst) and Fabiano Fidêncio (@fidencio) - Intel
 * Pradipta Banerjee (@bpradipt)  and Ariel Adam (@ariel-adam) - Red Hat
 * Samuel Ortiz (@sameo) - Rivos
 * Zvonko Kaiser (@zvonkok) - NVIDIA
 * Vincent Batts (@vbatts) and Ananya Garg (@angarg05) - Microsoft
+
+### Emeritus Members
+
+* Dan Middleton [dcmiddle](https://github.com/dcmiddle) (he/him)
 
 #### Selection
 


### PR DESCRIPTION
Recognizing Fabiano's (@fidencio) and Mikko's (@mythi) leadership in the community Intel is updating our representation on the Steering Committee. 

Fabiano will replace me now with the intent that Mikko take the next rotation to represent Intel.

_(I will continue my presence in CoCo submitting low quality PRs.. just not on the SC. 😄 )_