### PR TITLE
guides/sev: Add more details about sevctl installation

### DIFF
--- a/guides/sev.md
+++ b/guides/sev.md
@@ -35,7 +35,7 @@ Follow these steps to install `sevctl`:
   git clone https://github.com/virtee/sevctl.git
 
   # Build
-  (cd sevctl && cargo build)
+  (cd sevctl && cargo build && cargo install sevctl)
   ```
 
 * CentOS / Fedora / RHEL:


### PR DESCRIPTION
This PR adds an extra step that is needed to avoid a failure saying that sevctl is not being found, we need a step where we do the installation in order to generate properly for example a certificate.