### PR TITLE
guides/sev: Fix how to run the service of docker compose

### DIFF
--- a/guides/sev.md
+++ b/guides/sev.md
@@ -99,7 +99,7 @@ git clone https://github.com/confidential-containers/simple-kbs.git
 Run the service with `docker compose`:
 
 ```
-(cd simple-kbs && sudo docker compose up -d)
+(sudo docker compose up -d)
 ```
 
 ### Launch the Pod and Verify SEV Encryption


### PR DESCRIPTION
This PR fixes the step of how to run the service with docker compose by removing a step that was done previously and makes the command fail without this fix.