### PR TITLE
demos: Add io.containerd.cri.runtime-handler to the ssh demo

### DIFF
--- a/demos/ssh-demo/k8s-cc-ssh.yaml
+++ b/demos/ssh-demo/k8s-cc-ssh.yaml
@@ -20,6 +20,8 @@ spec:
     metadata:
       labels:
         app: ccv0-ssh
+      annotations:
+        io.containerd.cri.runtime-handler: kata
     spec:
       runtimeClassName: kata
       containers:


### PR DESCRIPTION
This is needed in order to ensure the nydus-snapshotter will behave properly when it's set in the runtime handler.