### PR TITLE
release-check-list: add pointer to operatorhub doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-check-list.md
+++ b/.github/ISSUE_TEMPLATE/release-check-list.md
@@ -110,4 +110,4 @@ assignees: ''
 
     * https://github.com/confidential-containers/confidential-containers/tree/main/releases/v<TARGET_RELEASE>.md
 
-- [ ] 23. Poke Wainer Moschetta (@wainersm) to update the release to the OperatorHub
+- [ ] 23. Poke Wainer Moschetta (@wainersm) to update the release to the OperatorHub. Find the documented flow [here](https://github.com/confidential-containers/operator/blob/main/docs/OPERATOR_HUB.md).


### PR DESCRIPTION
On last release I created a document on CoCo's operator explaining how the bundle can be updated to the Operator Hub. Updated this release check-list to link to that document.