### PR TITLE
governance: Update Intel's representation

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -78,7 +78,7 @@ The current members of the SC are:
 * Larry Dewey (@larrydewey) and Ryan Savino (@ryansavino) - AMD
 * Jiang Liu (@jiangliu) and Jia Zhang (@jiazhang0) - Alibaba
 * James Magowan (@magowan)  and Tobin Feldman-Fitzthum (@fitzthum) - IBM
-* Peter Zhu (@peterzcst) and Fabiano Fidêncio (@fidencio) - Intel
+* Peter Zhu (@peterzcst) and Mikko Ylinen (@mythi) - Intel
 * Pradipta Banerjee (@bpradipt)  and Ariel Adam (@ariel-adam) - Red Hat
 * Samuel Ortiz (@sameo) - Rivos
 * Zvonko Kaiser (@zvonkok) - NVIDIA


### PR DESCRIPTION
As I am off and will be off for some time due to a retina detachment, and its slow recovering process, I'd like to ensure we have the best candidate from Intel to step up and represent the company, and this person is, without any doubt, Mikko Ylinen.

Mikko has been deeply involved with SGX and TDX, both on Enclave CC, Kata Containers, and anything related to attestation.