### PR TITLE
governance: Update Intel's representation

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -78,7 +78,7 @@ The current members of the SC are:
 * Larry Dewey (@larrydewey) and Ryan Savino (@ryansavino) - AMD
 * Jiang Liu (@jiangliu) and Jia Zhang (@jiazhang0) - Alibaba
 * James Magowan (@magowan)  and Tobin Feldman-Fitzthum (@fitzthum) - IBM
-* Peter Zhu (@peterzcst) and Fabiano Fidêncio (@fidencio) - Intel
+* Peter Zhu (@peterzcst) and Mikko Ylinen (@mythi) - Intel
 * Pradipta Banerjee (@bpradipt)  and Ariel Adam (@ariel-adam) - Red Hat
 * Samuel Ortiz (@sameo) - Rivos
 * Zvonko Kaiser (@zvonkok) - NVIDIA


### PR DESCRIPTION
As I consider the merge to main really close to be finished at this point, and the most important things to come, at least for Intel, are related to ITA support on Trustee and, of course, Confidential Containers incubation, I'd like to nominate Mikko Ylinen to take my seat during this time.

I do believe that Peter Zhu and Mikko Ylinen are the key pieces to be representing Intel as part of the short-term future. :-)

Meanwhile, I'll still be around and contributing, but from the back seat, allowing Mikko and Peter to focus on the current goals.

With that said, please, join me to welcome Mikko to the Confidential Containers SC!