### PR TITLE
docs: Fix node label mismatch between repositories

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -31,7 +31,7 @@ To run the operator you must have an existing Kubernetes cluster that meets the 
 - Ensure a minimum of 8GB RAM and 4 vCPU for the Kubernetes cluster node
 - Only containerd runtime based Kubernetes clusters are supported with the current CoCo release
 - The minimum Kubernetes version should be 1.24
-- Ensure at least one Kubernetes node in the cluster is having the label `node-role.kubernetes.io/worker=`
+- Ensure at least one Kubernetes node in the cluster is having the label `node.kubernetes.io/worker=`
 - Ensure SELinux is disabled or not enforced (https://github.com/confidential-containers/operator/issues/115)
 
 For more details on the operator, including the custom resources managed by the operator, refer to the operator [docs](https://github.com/confidential-containers/operator).


### PR DESCRIPTION
Fix the following mismatch.

https://github.com/confidential-containers/confidential-containers/blob/main/quickstart.md#prerequisites
> Ensure at least one Kubernetes node in the cluster is having the label `node-role.kubernetes.io/worker=`

https://github.com/confidential-containers/operator/blob/862a6db5ac05c0727d6d7ff8ac7aab59e89f24f0/config/samples/ccruntime/base/ccruntime.yaml#L8-L10
```
  ccNodeSelector:
    matchLabels:
      node.kubernetes.io/worker: ""
```
