### PR TITLE
README: update OpenSSF Best Practices Badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Confidential Containers
 
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5719/badge)](https://bestpractices.coreinfrastructure.org/projects/5719)
+[![CII Best Practices](https://bestpractices.dev/projects/5719/badge)](https://bestpractices.dev/projects/5719)
 
 ## Welcome to confidential-containers
 


### PR DESCRIPTION
The old links are redirects to the new ones. The new ones are used by OpenSSF in their project related emails.