### PR TITLE
Update Release Notes for OpenSSF badge status

### DIFF
--- a/releases/v0.11.0.md
+++ b/releases/v0.11.0.md
@@ -73,8 +73,10 @@ The following are known limitations of this release:
 * Complete integration with Kubernetes is still in progress.
   * Existing APIs do not fully support the CoCo security and threat model. [More info](https://github.com/confidential-containers/community/issues/53)
   * Some commands accessing confidential data, such as `kubectl exec`, may either fail to work, or incorrectly expose information to the host
-* The CoCo community aspires to adopting open source security best practices, but not all practices are adopted yet.
-* Container metadata such as environment variables are not measured.
+* The CoCo community aspires to adopting open source security best practices.
+    * We track our status with the OpenSSF Best Practices Badge, which reached 100% of `Passing` criteria as of this release!
+    * Our next goal will be to complete `Silver` criteria. In reaching `Passing` status we also arrived at 11% of `Silver` criteria.
+e Container metadata such as environment variables are not measured.
 * The Kata Agent allows the host to call several dangerous endpoints
     * Kata Agent does not validate mount requests. A malicious host might be able to mount a shared filesystem into the PodVM.
     * Policy can be used to block endpoints, but it is not yet tied to the hardware evidence.


### PR DESCRIPTION
Having completed `Passing` we now pursue `Silver` criteria.
We intend to track this status each release like we did for `Passing`.