### PR TITLE
guides: remove link to CCv0 pages

### DIFF
--- a/guides/ephemeral_storage.md
+++ b/guides/ephemeral_storage.md
@@ -47,7 +47,6 @@ spec:
       storage: 1Gi
   storageClassName: open-local-lvm
 ```
-Before deploy the workload, we can follow this [documentation](https://github.com/kata-containers/kata-containers/blob/CCv0/docs/how-to/how-to-build-and-test-ccv0.md) and use [ccv0.sh](https://github.com/kata-containers/kata-containers/blob/CCv0/docs/how-to/ccv0.sh) to enable CoCo console debug(optional, check whether working as expected).
 
 Create the workload:
 ```sh


### PR DESCRIPTION
The link checker flagged these links. We don't really use these guides as documentation anymore. The website is preferred. Since we don't have a corresponding page on the website (and secure storage support is in flux), let's just delete these links rather than removing the entire file.

This should unblock #318 and #317