### PR TITLE
governance: SC update due to company transfer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,7 +3,7 @@
 # Github ID, Name, Affiliation
 
 ariel-adam, Ariel Adam, Redhat
-bpradipt, Pradipta Banerjee, Redhat
+beraldoleal, Beraldo Leal, Redhat
 bsulich2, Bartlomiej, Sulich, Intel
 mythi, Mikko Ylinen, Intel
 magowan, James Magowan, IBM

--- a/governance.md
+++ b/governance.md
@@ -134,7 +134,7 @@ The current members of the SC are:
 * James Magowan (@magowan) and Nina Goradia (@ngoradia) - IBM
 * Mikko Ylinen (@mythi) and Bartlomiej Sulich (@bsulich2) - Intel
 * Harshitha Gowda (@hgowda-amd) - AMD
-* Pradipta Banerjee (@bpradipt)  and Ariel Adam (@ariel-adam) - Red Hat
+* Beraldo Leal (@Beraldo Leal) and Ariel Adam (@ariel-adam) - Red Hat
 * Samuel Ortiz (@sameo) - Rivos
 * Zvonko Kaiser (@zvonkok) and Tobin Feldman-Fitzthum (@fitzthum) - NVIDIA
 * Magnus Kulke (@mkulke) and Dan Mihai (@danmihai1) - Microsoft


### PR DESCRIPTION
Beraldo will be the SC member from Red Hat replacing me as I have switched companies.
