### PR TITLE
release: update latest release notes to mention CVE

### DIFF
--- a/releases/v0.22.0.md
+++ b/releases/v0.22.0.md
@@ -6,6 +6,8 @@ This release is based on [4.0.0](https://github.com/kata-containers/kata-contain
 This Kata release adopts the Rust shim as the default for many runtime classes.
 Confidential Containers still uses the Go shim for now, but will transition in the future.
 
+**Due to [CVE-2026-77176](https://nvd.nist.gov/vuln/detail/CVE-2026-77176) use genpolicy tooling from the 4.1.0 Kata Release**
+
 This release uses v0.21.0 of Trustee and guest components.
 Trustee and the guest components use KBS protocol v0.4.0.
 


### PR DESCRIPTION
Our last release was based on Kata 4.0.0. Kata 4.1.0 patched a CVE in the genpolicy tool.

Since we do not directly provide this tool in our release, we did not cut a CoCo release based on 4.1.0 (which was an off release for us).

Since genpolicy is still an important component for CoCo users, add a note about the CVE suggesting that people use genpolicy from 4.1.0.